### PR TITLE
fix(act): handle CPU eval metrics without final_info

### DIFF
--- a/examples/baselines/act/act/evaluate.py
+++ b/examples/baselines/act/act/evaluate.py
@@ -21,8 +21,12 @@ def _append_eval_metrics(eval_metrics, info):
         if isinstance(final_info, dict):
             _append_episode_metrics(eval_metrics, final_info["episode"])
         else:
-            for final_info in final_info:
-                _append_episode_metrics(eval_metrics, final_info["episode"])
+            # Gymnasium leaves None in final_info for envs that did not terminate, and the
+            # companion _final_info mask says which entries are real. Neither is checked
+            # here because the caller asserts every env truncates on the same step, so this
+            # branch only ever sees a fully populated array.
+            for env_info in final_info:
+                _append_episode_metrics(eval_metrics, env_info["episode"])
         return
     if "episode" in info:
         _append_episode_metrics(eval_metrics, info["episode"])

--- a/examples/baselines/act/act/evaluate.py
+++ b/examples/baselines/act/act/evaluate.py
@@ -5,6 +5,31 @@ import torch
 
 from mani_skill.utils import common
 
+
+def _append_episode_metrics(eval_metrics, episode):
+    for k, v in episode.items():
+        if k.startswith("_"):
+            continue
+        if isinstance(v, torch.Tensor):
+            v = v.float().cpu().numpy()
+        eval_metrics[k].append(v)
+
+
+def _append_eval_metrics(eval_metrics, info):
+    if "final_info" in info:
+        final_info = info["final_info"]
+        if isinstance(final_info, dict):
+            _append_episode_metrics(eval_metrics, final_info["episode"])
+        else:
+            for final_info in final_info:
+                _append_episode_metrics(eval_metrics, final_info["episode"])
+        return
+    if "episode" in info:
+        _append_episode_metrics(eval_metrics, info["episode"])
+        return
+    raise KeyError("expected info['final_info'] or info['episode'] with episode metrics")
+
+
 def evaluate(n: int, agent, eval_envs, eval_kwargs):
     stats, num_queries, temporal_agg, max_timesteps, device, sim_backend = eval_kwargs.values()
 
@@ -80,13 +105,7 @@ def evaluate(n: int, agent, eval_envs, eval_kwargs):
             # collect episode info
             if truncated.any():
                 assert truncated.all() == truncated.any(), "all episodes should truncate at the same time for fair evaluation with other algorithms"
-                if isinstance(info["final_info"], dict):
-                    for k, v in info["final_info"]["episode"].items():
-                        eval_metrics[k].append(v.float().cpu().numpy())
-                else:
-                    for final_info in info["final_info"]:
-                        for k, v in final_info["episode"].items():
-                            eval_metrics[k].append(v)
+                _append_eval_metrics(eval_metrics, info)
                 # new episodes begin
                 eps_count += num_envs
                 ts = 0

--- a/tests/test_act_evaluate.py
+++ b/tests/test_act_evaluate.py
@@ -1,0 +1,97 @@
+import importlib.util
+import sys
+import types
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+
+def load_act_evaluate():
+    common = types.ModuleType("common")
+    utils = types.ModuleType("mani_skill.utils")
+    utils.common = common
+
+    sys.modules["mani_skill"] = types.ModuleType("mani_skill")
+    sys.modules["mani_skill.utils"] = utils
+    sys.modules["mani_skill.utils.common"] = common
+
+    evaluate_path = (
+        Path(__file__).resolve().parents[1]
+        / "examples"
+        / "baselines"
+        / "act"
+        / "act"
+        / "evaluate.py"
+    )
+    spec = importlib.util.spec_from_file_location("act_evaluate", evaluate_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_append_eval_metrics_reads_vector_final_info_dict():
+    module = load_act_evaluate()
+    metrics = defaultdict(list)
+
+    module._append_eval_metrics(
+        metrics,
+        {
+            "final_info": {
+                "episode": {
+                    "return": torch.tensor([1.0, 2.0]),
+                    "success_at_end": torch.tensor([True, False]),
+                }
+            }
+        },
+    )
+
+    np.testing.assert_array_equal(metrics["return"][0], np.array([1.0, 2.0]))
+    np.testing.assert_array_equal(metrics["success_at_end"][0], np.array([1.0, 0.0]))
+
+
+def test_append_eval_metrics_reads_vector_final_info_list():
+    module = load_act_evaluate()
+    metrics = defaultdict(list)
+
+    module._append_eval_metrics(
+        metrics,
+        {
+            "final_info": [
+                {"episode": {"return": np.array(1.0)}},
+                {"episode": {"return": np.array(2.0)}},
+            ]
+        },
+    )
+
+    assert metrics["return"] == [np.array(1.0), np.array(2.0)]
+
+
+def test_append_eval_metrics_falls_back_to_cpu_episode_info():
+    module = load_act_evaluate()
+    metrics = defaultdict(list)
+
+    module._append_eval_metrics(
+        metrics,
+        {
+            "episode": {
+                "return": np.array([1.0, 2.0]),
+                "_return": np.array([True, True]),
+                "success_at_end": np.array([True, False]),
+                "_success_at_end": np.array([True, True]),
+            }
+        },
+    )
+
+    assert set(metrics) == {"return", "success_at_end"}
+    np.testing.assert_array_equal(metrics["return"][0], np.array([1.0, 2.0]))
+    np.testing.assert_array_equal(metrics["success_at_end"][0], np.array([True, False]))
+
+
+def test_append_eval_metrics_requires_episode_metrics():
+    module = load_act_evaluate()
+
+    with pytest.raises(KeyError, match="final_info.*episode"):
+        module._append_eval_metrics(defaultdict(list), {})


### PR DESCRIPTION
## Summary
- Handle ACT evaluation metrics from CPU vector envs that expose metrics under `info["episode"]` instead of `info["final_info"]`.
- Preserve the existing `final_info` handling for ManiSkillVectorEnv/GPU paths.
- Normalize tensor metrics to CPU NumPy arrays across supported info shapes and exclude Gymnasium `_`-prefixed mask keys from returned metrics.
- Add focused regression coverage for the supported ACT evaluation info shapes.

## Why
- Fixes `KeyError: 'final_info'` when ACT evaluation runs with `physx_cpu` and `CPUGymWrapper(record_metrics=True)`.
- Keeps metric element types consistent before the existing `np.stack` step.
- Prevents Gymnasium mask arrays from being returned as metrics.
- Closes #1408.

## Validation
- [x] `python -m compileall examples/baselines/act/act/evaluate.py`
- [x] `pytest tests/test_act_evaluate.py -q`

## Notes for reviewers
- Full ManiSkill simulation smoke test was not run locally because `sapien` is not installed in this environment.
- Handling `None` entries inside asynchronous `final_info` arrays remains unchanged; this evaluation loop currently asserts synchronous truncation.