### PR TITLE
[Chore] Deprecate StereoDepthCamera

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,7 +100,7 @@ autoapi_ignore = [
     "*/mani_skill/agents/robots/*.py",
     "*/mani_skill/examples/*.py",
     "*/mani_skill/render/*.py",
-    # depth_camera is outdated and needs to be upgraded
+    # depth_camera contains the deprecated legacy SAPIEN stereo depth sensor
     "*/mani_skill/sensors/depth_camera.py",
 ]
 autoapi_keep_files = True

--- a/docs/source/user_guide/concepts/sensors.md
+++ b/docs/source/user_guide/concepts/sensors.md
@@ -6,6 +6,15 @@ This page documents how to use / customize sensors and cameras in ManiSkill in d
 
 Cameras in ManiSkill can capture a ton of different modalities/textures of data. By default ManiSkill limits those to just `rgb`, `depth`, `position` (which is used to derive depth), and `segmentation`. Internally ManiSkill uses [SAPIEN](https://sapien.ucsd.edu/) which has a highly optimized rendering system that leverages shaders to render different modalities of data. The full set of configurations for cameras can be found in {py:class}`mani_skill.sensors.camera.CameraConfig`.
 
+```{deprecated} 3.0
+`StereoDepthCamera` and `StereoDepthCameraConfig` are no longer maintained and
+will be removed in a future release. Use the standard
+{py:class}`mani_skill.sensors.camera.Camera` and
+{py:class}`mani_skill.sensors.camera.CameraConfig` instead. Depth observations
+are available by selecting `obs_mode="depth"` or `obs_mode="rgbd"` when creating
+an environment.
+```
+
 Each shader has a preset configuration that generates image-like data, often in a somewhat difficult to use format due to heavy optimization. ManiSkill uses a shader configuration system in python that parses these different shaders into more user friendly texture formats like `rgb` and `depth`. See the [next section on the shaders](#shaders-and-textures) for more details about what textures are available to generate for which shader and their default shape/types.
 
 

--- a/mani_skill/sensors/depth_camera.py
+++ b/mani_skill/sensors/depth_camera.py
@@ -1,5 +1,4 @@
-# TODO (stao): reimplement this
-
+import warnings
 
 import numpy as np
 import sapien
@@ -15,9 +14,22 @@ from mani_skill.utils import sapien_utils
 
 from .camera import Camera, CameraConfig
 
+_STEREO_DEPTH_CAMERA_DEPRECATION_MESSAGE = (
+    "StereoDepthCamera and StereoDepthCameraConfig are deprecated and will be "
+    "removed in a future release. Use Camera and CameraConfig with depth "
+    'observations (for example, obs_mode="depth" or obs_mode="rgbd") instead.'
+)
+
 
 class StereoDepthCameraConfig(CameraConfig):
+    """Deprecated configuration for the legacy SAPIEN stereo depth sensor."""
+
     def __init__(self, *args, min_depth: float = 0.05, **kwargs):
+        warnings.warn(
+            _STEREO_DEPTH_CAMERA_DEPRECATION_MESSAGE,
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(*args, **kwargs)
         self.min_depth = min_depth
 
@@ -36,6 +48,8 @@ class StereoDepthCameraConfig(CameraConfig):
 
 
 class StereoDepthCamera(Camera):
+    """Deprecated wrapper for the legacy SAPIEN stereo depth sensor."""
+
     def __init__(
         self,
         camera_cfg: StereoDepthCameraConfig,

--- a/tests/sensors/test_depth_camera_deprecation.py
+++ b/tests/sensors/test_depth_camera_deprecation.py
@@ -1,0 +1,49 @@
+import warnings
+
+import sapien
+
+from mani_skill.sensors.camera import CameraConfig, update_sensor_configs_from_dict
+from mani_skill.sensors.depth_camera import (
+    _STEREO_DEPTH_CAMERA_DEPRECATION_MESSAGE,
+    StereoDepthCameraConfig,
+)
+
+
+def make_camera_config():
+    return CameraConfig(
+        uid="camera",
+        pose=sapien.Pose(),
+        width=64,
+        height=64,
+        fov=1.0,
+    )
+
+
+def test_stereo_depth_camera_config_warns_on_direct_use():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        StereoDepthCameraConfig(
+            uid="camera",
+            pose=sapien.Pose(),
+            width=64,
+            height=64,
+            fov=1.0,
+        )
+
+    assert len(caught) == 1
+    assert caught[0].category is DeprecationWarning
+    assert str(caught[0].message) == _STEREO_DEPTH_CAMERA_DEPRECATION_MESSAGE
+    assert caught[0].filename == __file__
+
+
+def test_use_stereo_depth_override_warns():
+    sensor_configs = {"camera": make_camera_config()}
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        update_sensor_configs_from_dict(sensor_configs, {"use_stereo_depth": True})
+
+    assert len(caught) == 1
+    assert caught[0].category is DeprecationWarning
+    assert str(caught[0].message) == _STEREO_DEPTH_CAMERA_DEPRECATION_MESSAGE
+    assert isinstance(sensor_configs["camera"], StereoDepthCameraConfig)


### PR DESCRIPTION
## Summary

- emit a standard `DeprecationWarning` when `StereoDepthCameraConfig` is used, including through the `use_stereo_depth` runtime override
- document migration to `Camera`/`CameraConfig` with `depth` or `rgbd` observation modes
- add regression coverage for direct config construction and runtime override conversion

Fixes #1458.

## Validation

- targeted deprecation tests: 2 passed (Python 3.12, SAPIEN 3.0.3)
- `black --check` on the changed Python files
- `isort --check-only --profile=black` on the changed Python files
- Python syntax compilation
- `git diff --check`