### PR TITLE
[BugFix] Fix package logger configuration

### DIFF
--- a/mani_skill/utils/logging_utils.py
+++ b/mani_skill/utils/logging_utils.py
@@ -53,12 +53,17 @@ class CustomFormatter(logging.Formatter):
         return s
 
 
-logger = logging.getLogger("mani_skill ")
-logger.setLevel(logging.INFO)
-logger.propagate = False
-if not logger.hasHandlers():
-    ch = logging.StreamHandler()
-    ch.setFormatter(
-        CustomFormatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-    )
-    logger.addHandler(ch)
+def _configure_logger(name: str) -> logging.Logger:
+    package_logger = logging.getLogger(name)
+    package_logger.setLevel(logging.INFO)
+    package_logger.propagate = False
+    if not package_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            CustomFormatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        )
+        package_logger.addHandler(handler)
+    return package_logger
+
+
+logger = _configure_logger("mani_skill")

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,48 @@
+import logging
+
+from mani_skill.utils.logging_utils import CustomFormatter, _configure_logger, logger
+
+
+def remove_logger(name):
+    candidate = logging.getLogger(name)
+    candidate.handlers.clear()
+    logging.Logger.manager.loggerDict.pop(name, None)
+
+
+def test_package_logger_uses_package_namespace():
+    assert logger.name == "mani_skill"
+
+
+def test_configure_logger_adds_local_handler_when_root_has_handler(capsys):
+    name = "mani_skill.tests.root_handler"
+    root_handler = logging.NullHandler()
+    logging.getLogger().addHandler(root_handler)
+    remove_logger(name)
+
+    try:
+        configured = _configure_logger(name)
+
+        assert configured.propagate is False
+        assert len(configured.handlers) == 1
+        assert isinstance(configured.handlers[0], logging.StreamHandler)
+        assert isinstance(configured.handlers[0].formatter, CustomFormatter)
+        configured.info("local handler is active")
+        assert "local handler is active" in capsys.readouterr().err
+    finally:
+        remove_logger(name)
+        logging.getLogger().removeHandler(root_handler)
+
+
+def test_configure_logger_does_not_duplicate_handlers():
+    name = "mani_skill.tests.idempotent"
+    remove_logger(name)
+
+    try:
+        first = _configure_logger(name)
+        initial_handler = first.handlers[0]
+        second = _configure_logger(name)
+
+        assert first is second
+        assert second.handlers == [initial_handler]
+    finally:
+        remove_logger(name)


### PR DESCRIPTION
## Summary

- use the canonical `mani_skill` logger namespace instead of the existing name with a trailing space
- configure the package logger from a small idempotent helper
- check local handlers directly so an application-level root handler cannot silently suppress ManiSkill logs while propagation is disabled
- add regression coverage for the logger name, root-handler case, emitted output, and repeated configuration

This is the first incremental part of #1434. Migrating or automatically checking remaining package `print` calls can follow separately without mixing CLI-output policy into this bug fix.

## Validation

- targeted logging tests: 3 passed (Python 3.12)
- `black --check` on the changed Python files
- `isort --check-only --profile=black` on the changed Python files
- Python syntax compilation
- `git diff --check`